### PR TITLE
Use encodeURIComponent for Legado text template

### DIFF
--- a/src/app/ra/export.test.tsx
+++ b/src/app/ra/export.test.tsx
@@ -46,6 +46,7 @@ vi.mock(
 vi.mock(import("./generate-profile"), () => ({
   generateProfileLegado: mocks.generate.legado,
   generateProfileIreadnote: mocks.generate.ireadnote,
+  DEFAULT_LEGADO_TEXT_ENCODING: "encodeURIComponent",
 }));
 
 vi.stubGlobal("navigator", {
@@ -199,6 +200,29 @@ describe("legado export", () => {
       expect.anything(),
       expect.objectContaining({
         rateTemplate: "{{(speakSpeed-4.9)/30+0.5}}",
+      })
+    );
+  });
+  test("text encoding compat mode applied", async () => {
+    const user = userEvent.setup();
+    render(<ExportRa />, {
+      wrapper: ({ children }) => (
+        <TestProvider
+          // @ts-expect-error ignore
+          initialValues={[
+            [raApiConfigAtom, { url: "https://example.com", token: "" }],
+          ]}
+        >
+          {children}
+        </TestProvider>
+      ),
+    });
+    await user.click(screen.getByRole("radio", { name: /兼容模式/ }));
+    await user.click(screen.getByRole("button"));
+    expect(mocks.generate.legado).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        textEncoding: "xmlEscape",
       })
     );
   });

--- a/src/app/ra/export.test.tsx
+++ b/src/app/ra/export.test.tsx
@@ -46,7 +46,7 @@ vi.mock(
 vi.mock(import("./generate-profile"), () => ({
   generateProfileLegado: mocks.generate.legado,
   generateProfileIreadnote: mocks.generate.ireadnote,
-  DEFAULT_LEGADO_TEXT_ENCODING: "encodeURIComponent",
+  DEFAULT_LEGADO_TEXT_ENCODING: "encodeURIComponent" as const,
 }));
 
 vi.stubGlobal("navigator", {

--- a/src/app/ra/export.tsx
+++ b/src/app/ra/export.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from "jotai";
 import { toast } from "sonner";
 import {
   LegadoSpecificConfig,
+  LegadoTextEncoding,
   RaApiConfig,
   raApiConfigAtom,
   RaState,
@@ -15,6 +16,7 @@ import {
 import {
   generateProfileLegado,
   generateProfileIreadnote,
+  DEFAULT_LEGADO_TEXT_ENCODING,
 } from "@/app/ra/generate-profile";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { posthog } from "posthog-js";
@@ -22,6 +24,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TabsContent } from "@radix-ui/react-tabs";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useState } from "react";
 
 function copyToClipboard(text: string) {
@@ -113,6 +116,7 @@ function LegadoSpecificConfigComp({
   config: LegadoSpecificConfig;
   setConfig: (config: LegadoSpecificConfig) => void;
 }) {
+  const textEncoding = config.textEncoding ?? DEFAULT_LEGADO_TEXT_ENCODING;
   return (
     <div>
       <Label className="mt-4 flex flex-col gap-2 items-start">
@@ -131,6 +135,38 @@ function LegadoSpecificConfigComp({
           除非必要，请勿修改（保持留空即为默认值）。
           <a
             href="https://github.com/yy4382/read-aloud/issues/12#issuecomment-3334516431"
+            className="text-blue-500 underline"
+          >
+            查看详情
+          </a>
+        </p>
+      </div>
+      <div className="mt-4 flex flex-col gap-2 items-start">
+        <Label>兼容模式</Label>
+        <RadioGroup
+          value={textEncoding}
+          onValueChange={(value) =>
+            setConfig({
+              ...config,
+              textEncoding: value as LegadoTextEncoding,
+            })
+          }
+        >
+          <Label className="flex items-center gap-2 font-normal">
+            <RadioGroupItem value="encodeURIComponent" />
+            默认
+          </Label>
+          <Label className="flex items-center gap-2 font-normal">
+            <RadioGroupItem value="xmlEscape" />
+            兼容模式
+          </Label>
+        </RadioGroup>
+      </div>
+      <div className="prose dark:prose-invert prose-sm mt-2 prose-p:my-1">
+        <p>
+          一般保持默认即可。如果导入后朗读报错或没有声音，请切换到兼容模式再试。
+          <a
+            href="https://github.com/yy4382/tts-importer/pull/33#issuecomment-4586817872"
             className="text-blue-500 underline"
           >
             查看详情

--- a/src/app/ra/generate-profile.test.ts
+++ b/src/app/ra/generate-profile.test.ts
@@ -108,6 +108,26 @@ describe("generateProfileLegado", () => {
     expect(config.url).toContain("rate={{customRate}}");
   });
 
+  it("defaults to the encodeURIComponent text template", () => {
+    const state = createState();
+
+    const result = generateProfileLegado(state, {});
+    const config = JSON.parse(result) as { url: string };
+
+    expect(config.url).toContain("text={{encodeURIComponent(speakText)}}");
+  });
+
+  it("uses the legacy replace template in xmlEscape compat mode", () => {
+    const state = createState();
+
+    const result = generateProfileLegado(state, { textEncoding: "xmlEscape" });
+    const config = JSON.parse(result) as { url: string };
+
+    expect(config.url).toContain("String(speakText).replace(");
+    expect(config.url).toContain("&amp;");
+    expect(config.url).not.toContain("encodeURIComponent");
+  });
+
   it("builds multiple entries when multiple voices supplied", () => {
     const state = createState({
       voice: {

--- a/src/app/ra/generate-profile.ts
+++ b/src/app/ra/generate-profile.ts
@@ -1,5 +1,6 @@
 import {
   LegadoSpecificConfig,
+  LegadoTextEncoding,
   raApiConfigSchema,
   RaState,
   raVoiceConfigAdvancedSchema,
@@ -13,6 +14,23 @@ function getSynthesisUrl(apiBase: string) {
   return url;
 }
 export const DEFAULT_LEGADO_RATE_TEMPLATE = "{{speakSpeed/10}}";
+
+export const DEFAULT_LEGADO_TEXT_ENCODING: LegadoTextEncoding =
+  "encodeURIComponent";
+
+/**
+ * Legado-style apps embed a JS-like expression for the `text` param. Different
+ * readers support different runtimes, so we offer multiple "compat modes":
+ * - `encodeURIComponent` (default): correctly handles `%` and other reserved
+ *   characters, but requires the reader to expose `encodeURIComponent`.
+ * - `xmlEscape`: the legacy fallback that only does `String.replace`, which
+ *   more limited template parsers support.
+ */
+const LEGADO_TEXT_TEMPLATES: Record<LegadoTextEncoding, string> = {
+  encodeURIComponent: "{{encodeURIComponent(speakText)}}",
+  xmlEscape: `{{String(speakText).replace(/&/g, '&amp;').replace(/\\"/g, '&quot;').replace(/'/g, '&apos;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}}`,
+};
+
 function buildLegadoUrl(
   api: z.infer<typeof raApiConfigSchema>,
   voiceName: string,
@@ -21,6 +39,10 @@ function buildLegadoUrl(
 ) {
   const { pitch, volume, format } = advanced;
   const rate = legadoSpecific.rateTemplate || DEFAULT_LEGADO_RATE_TEMPLATE;
+  const textTemplate =
+    LEGADO_TEXT_TEMPLATES[
+      legadoSpecific.textEncoding ?? DEFAULT_LEGADO_TEXT_ENCODING
+    ];
   const url = getSynthesisUrl(api.url);
   const { token } = api;
   url.searchParams.set("voiceName", voiceName);
@@ -28,7 +50,7 @@ function buildLegadoUrl(
   if (volume) url.searchParams.set("volume", volume);
   if (token) url.searchParams.set("token", token);
   if (format) url.searchParams.set("format", format);
-  return `${url.toString()}&rate=${rate}&text={{encodeURIComponent(speakText)}}`;
+  return `${url.toString()}&rate=${rate}&text=${textTemplate}`;
 }
 
 export function generateProfileLegado(state: RaState, legadoSpecific: LegadoSpecificConfig) {

--- a/src/app/ra/generate-profile.ts
+++ b/src/app/ra/generate-profile.ts
@@ -28,7 +28,7 @@ function buildLegadoUrl(
   if (volume) url.searchParams.set("volume", volume);
   if (token) url.searchParams.set("token", token);
   if (format) url.searchParams.set("format", format);
-  return `${url.toString()}&rate=${rate}&text={{String(speakText).replace(/&/g, '&amp;').replace(/\\\"/g, '&quot;').replace(/'/g, '&apos;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}}`;
+  return `${url.toString()}&rate=${rate}&text={{encodeURIComponent(speakText)}}`;
 }
 
 export function generateProfileLegado(state: RaState, legadoSpecific: LegadoSpecificConfig) {

--- a/src/app/ra/ra-data.ts
+++ b/src/app/ra/ra-data.ts
@@ -112,8 +112,15 @@ export {
   raStateSchema,
 };
 
+export const legadoTextEncodingSchema = z.enum([
+  "encodeURIComponent",
+  "xmlEscape",
+]);
+export type LegadoTextEncoding = z.infer<typeof legadoTextEncodingSchema>;
+
 export const legadoSpecificConfigSchema = z.object({
   rateTemplate: z.string().optional(),
+  textEncoding: legadoTextEncodingSchema.optional(),
 });
 export type LegadoSpecificConfig = z.infer<typeof legadoSpecificConfigSchema>;
 


### PR DESCRIPTION
把url的replace链改为 encodeURIComponent，防止在处理“%”时错误编码url。

但是我并没有广泛测试兼容性，只在legado-md3上测试过是可用的